### PR TITLE
exclude regular Julia number types from Open62541 specific show methods

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -96,7 +96,7 @@ for (i, type_name) in enumerate(type_names)
     @eval begin
         # Datatype map functions
         ua_data_type_ptr(::$(val_type)) = UA_TYPES_PTRS[$(i - 1)]
-        if type_names[$(i)] ∉ types_ambiguous_ignorelist
+        if type_names[$(i)] ∉ types_ambiguous_ignorelist && !(julia_types[$(i)] <: UA_NUMBER_TYPES)
             ua_data_type_ptr_default(::Type{$(julia_type)}) = UA_TYPES_PTRS[$(i - 1)]
             function ua_data_type_ptr_default(::Type{Ptr{$julia_type}})
                 ua_data_type_ptr_default($julia_type)

--- a/src/types.jl
+++ b/src/types.jl
@@ -96,12 +96,14 @@ for (i, type_name) in enumerate(type_names)
     @eval begin
         # Datatype map functions
         ua_data_type_ptr(::$(val_type)) = UA_TYPES_PTRS[$(i - 1)]
-        if type_names[$(i)] ∉ types_ambiguous_ignorelist && !(julia_types[$(i)] <: UA_NUMBER_TYPES)
+        if type_names[$(i)] ∉ types_ambiguous_ignorelist
             ua_data_type_ptr_default(::Type{$(julia_type)}) = UA_TYPES_PTRS[$(i - 1)]
             function ua_data_type_ptr_default(::Type{Ptr{$julia_type}})
                 ua_data_type_ptr_default($julia_type)
             end
-            Base.show(io::IO, ::MIME"text/plain", v::$(julia_type)) = print(io, UA_print(v))
+            if !(julia_types[$(i)] <: UA_NUMBER_TYPES)
+                Base.show(io::IO, ::MIME"text/plain", v::$(julia_type)) = print(io, UA_print(v))
+            end
         end
 
         # Datatype specific constructors, destructors, initalizers, as well as clear and copy functions


### PR DESCRIPTION
Before this change:
```
a = 1
"1"
```
which was confusing sometimes, because it wasn't distinguishable from:
```
a = "1"
"1"
```

With the change here, we are back to then normal Julia way of showing for these basic number types:
```
a = 1
1
```
