### PR TITLE
Introduces automated reconnecting for high level client functions, restructures client connect functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Open62541"
 uuid = "e9b70463-8ccb-4e30-a2e2-0d1ec8db6536"
 authors = ["Martin Kosch <martin.kosch@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Open62541 = "e9b70463-8ccb-4e30-a2e2-0d1ec8db6536"
 
 [compat]
 Documenter = "1"
-Open62541 = "0.1, 0.2, 0.3"
+Open62541 = "0.1, 0.2, 0.3, 0.4"

--- a/docs/src/manual/client.md
+++ b/docs/src/manual/client.md
@@ -74,5 +74,5 @@ UA_Client_writeWriteMaskAttribute
 ```@autodocs; canonical = false
 Modules = [Open62541]
 Order = [:function]
-Filter = t -> startswith(string(t), "UA_ClientAsync") && !endswith(string(t), "_generate")
+Filter = t -> startswith(string(t), "UA_Client") && contains(string(t), "Async")
 ```

--- a/docs/src/reference_lowlevel.md
+++ b/docs/src/reference_lowlevel.md
@@ -13,12 +13,14 @@ Filter = t -> startswith(string(t), "UA_")
 ## Memory allocation and management for open62541 types
 
 These are low level functions allowing to allocate and free (etc.) memory for
-open62541 types ("UA_...") on the C-side.
+open62541 types ("UA_...") on the C-side, as well as comparison between objects of the same 
+type.
 
 ```@autodocs
 Modules = [Open62541]
 Order = [:function]
-Filter = t -> startswith(string(t), "UA_") && any(endswith.(string(t), ["_new", "_init", "_delete", "_clear", "_copy", "_deleteMembers"]))
+Filter = t -> startswith(string(t), "UA_") && any(endswith.(string(t), ["_new", "_init", 
+    "_delete", "_clear", "_copy", "_equal", "_deleteMembers"]))
 ```
 
 ## Convenience functions for generating strings/bytestrings & associated functions
@@ -28,10 +30,6 @@ UA_BYTESTRING
 UA_BYTESTRING_ALLOC
 UA_STRING
 UA_STRING_ALLOC
-```
-
-```@docs
-UA_ByteString_equal
 ```
 
 ## Generation of (Expanded)NodeIds & associated functions
@@ -46,10 +44,6 @@ Filter = t -> startswith(string(t), "UA_NODEID")
 Modules = [Open62541]
 Order = [:function]
 Filter = t -> startswith(string(t), "UA_EXPANDEDNODEID") 
-```
-
-```@docs
-UA_NodeId_equal
 ```
 
 ## Attribute generation
@@ -92,7 +86,12 @@ Filter = t -> startswith(string(t), "UA_Server_") || startswith(string(t), "UA_S
 ```@autodocs
 Modules = [Open62541]
 Order = [:function]
-Filter = t -> startswith(string(t), "UA_Client_")
+Filter = t -> startswith(string(t), "UA_Client_") && !contains(string(t), "Async") &&
+    !contains(string(t), "async")
+```
+
+```@docs
+UA_ClientConfig_setAuthenticationUsername
 ```
 
 ## Asynchronous Client API
@@ -100,7 +99,8 @@ Filter = t -> startswith(string(t), "UA_Client_")
 ```@autodocs
 Modules = [Open62541]
 Order = [:function]
-Filter = t -> startswith(string(t), "UA_ClientAsync") && !endswith(string(t), "_generate")
+Filter = t -> startswith(string(t), "UA_Client_") && (contains(string(t), "Async") || 
+    contains(string(t), "async"))
 ```
 
 ## Callback generation

--- a/gen/callbacks_base.jl
+++ b/gen/callbacks_base.jl
@@ -98,7 +98,7 @@ function UA_MethodCallback_generate(f::Function)
     returntype = UA_StatusCode
     ret = Base.return_types(f, argtuple)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
-       ret[1] == returntype
+            ret[1] == returntype
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid},
                 Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId}, Ptr{Cvoid},
@@ -189,7 +189,7 @@ function UA_ValueCallback_onRead_generate(f::Function)
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -222,7 +222,7 @@ function UA_ValueCallback_onWrite_generate(f::Function)
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -255,7 +255,7 @@ function UA_DataSourceCallback_write_generate(f::Function)
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -288,7 +288,7 @@ function UA_DataSourceCallback_read_generate(f::Function)
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, UA_Boolean, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -312,7 +312,7 @@ function UA_ServerCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Server}, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -336,7 +336,7 @@ function UA_ClientCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Client}, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -360,7 +360,7 @@ function UA_ClientAsyncServiceCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -385,7 +385,7 @@ function UA_ClientAsyncReadCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_ReadResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -410,7 +410,7 @@ function UA_ClientAsyncWriteCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_WriteResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -435,7 +435,7 @@ function UA_ClientAsyncBrowseCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_BrowseResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -460,7 +460,7 @@ function UA_ClientAsyncAddNodesCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_AddNodesResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -485,7 +485,83 @@ function UA_ClientAsyncCallCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_CallResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_stateCallback_generate(f::Function)
+```
+
+creates a function pointer for the `stateCallback` field of a `UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}, channelstate::UInt32, sessionstate::UInt32, connecstatus::UInt32))::Nothing`
+"""
+function UA_ClientConfig_stateCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client}, UInt32, UInt32, UInt32)
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+            (Ptr{UA_Client}, UInt32, UInt32, UInt32))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_inactivityCallback_generate(f::Function)
+```
+
+creates a function pointer for the `inactivityCallback` field of a `UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}))::Nothing`
+"""
+function UA_ClientConfig_inactivityCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client},)
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+            (Ptr{UA_Client},))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_subscriptionInactivityCallback_generate(f::Function)
+```
+
+creates a function pointer for the `subscriptionInactivityCallback` field of a 
+`UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}, subscritionid::UInt32, subcontext::Ptr{CVoid}))::Nothing`
+"""
+function UA_ClientConfig_subscriptionInactivityCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client}, UInt32, Ptr{Cvoid})
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+           (Ptr{UA_Client}, UInt32, Ptr{Cvoid}))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -1371,127 +1447,6 @@ end
 #     /* Add more function pointer here.
 #      * For example for read_event, read_annotation, update_details */
 # };
-
-# typedef struct {
-#     void *clientContext; /* User-defined pointer attached to the client */
-#     UA_Logger logger;    /* Logger used by the client */
-#     UA_UInt32 timeout;   /* Response timeout in ms */
-
-#     /* The description must be internally consistent.
-#      * - The ApplicationUri set in the ApplicationDescription must match the
-#      *   URI set in the certificate */
-#     UA_ApplicationDescription clientDescription;
-
-#     /**
-#      * Connection configuration
-#      * ~~~~~~~~~~~~~~~~~~~~~~~~
-#      *
-#      * The following configuration elements reduce the "degrees of freedom" the
-#      * client has when connecting to a server. If no connection can be made
-#      * under these restrictions, then the connection will abort with an error
-#      * message. */
-#     UA_ExtensionObject userIdentityToken; /* Configured User-Identity Token */
-#     UA_MessageSecurityMode securityMode;  /* None, Sign, SignAndEncrypt. The
-#                                            * default is invalid. This indicates
-#                                            * the client to select any matching
-#                                            * endpoint. */
-#     UA_String securityPolicyUri; /* SecurityPolicy for the SecureChannel. An
-#                                   * empty string indicates the client to select
-#                                   * any matching SecurityPolicy. */
-
-#     /**
-#      * If either endpoint or userTokenPolicy has been set (at least one non-zero
-#      * byte in either structure), then the selected Endpoint and UserTokenPolicy
-#      * overwrite the settings in the basic connection configuration. The
-#      * userTokenPolicy array in the EndpointDescription is ignored. The selected
-#      * userTokenPolicy is set in the dedicated configuration field.
-#      *
-#      * If the advanced configuration is not set, the client will write to it the
-#      * selected Endpoint and UserTokenPolicy during GetEndpoints.
-#      *
-#      * The information in the advanced configuration is used during reconnect
-#      * when the SecureChannel was broken. */
-#     UA_EndpointDescription endpoint;
-#     UA_UserTokenPolicy userTokenPolicy;
-
-#     /**
-#      * If the EndpointDescription has not been defined, the ApplicationURI
-#      * constrains the servers considered in the FindServers service and the
-#      * Endpoints considered in the GetEndpoints service.
-#      *
-#      * If empty the applicationURI is not used to filter.
-#      */
-#     UA_String applicationUri;
-
-#     /**
-#      * Custom Data Types
-#      * ~~~~~~~~~~~~~~~~~
-#      * The following is a linked list of arrays with custom data types. All data
-#      * types that are accessible from here are automatically considered for the
-#      * decoding of received messages. Custom data types are not cleaned up
-#      * together with the configuration. So it is possible to allocate them on
-#      * ROM.
-#      *
-#      * See the section on :ref:`generic-types`. Examples for working with custom
-#      * data types are provided in ``/examples/custom_datatype/``. */
-#     const UA_DataTypeArray *customDataTypes;
-
-#     /**
-#      * Advanced Client Configuration
-#      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#     UA_UInt32 secureChannelLifeTime; /* Lifetime in ms (then the channel needs
-#                                         to be renewed) */
-#     UA_UInt32 requestedSessionTimeout; /* Session timeout in ms */
-#     UA_ConnectionConfig localConnectionConfig;
-#     UA_UInt32 connectivityCheckInterval;     /* Connectivity check interval in ms.
-#                                               * 0 = background task disabled */
-#     /* Available SecurityPolicies */
-#     size_t securityPoliciesSize;
-#     UA_SecurityPolicy *securityPolicies;
-
-#     /* Certificate Verification Plugin */
-#     UA_CertificateVerification certificateVerification;
-
-#     /* Callbacks for async connection handshakes */
-#     UA_ConnectClientConnection initConnectionFunc;
-#     UA_StatusCode (*pollConnectionFunc)(UA_Connection *connection,
-#                                         UA_UInt32 timeout,
-#                                         const UA_Logger *logger);
-
-#     /* Callback for state changes. The client state is differentated into the
-#      * SecureChannel state and the Session state. The connectStatus is set if
-#      * the client connection (including reconnects) has failed and the client
-#      * has to "give up". If the connectStatus is not set, the client still has
-#      * hope to connect or recover. */
-#     void (*stateCallback)(UA_Client *client,
-#                           UA_SecureChannelState channelState,
-#                           UA_SessionState sessionState,
-#                           UA_StatusCode connectStatus);
-
-#     /* When connectivityCheckInterval is greater than 0, every
-#      * connectivityCheckInterval (in ms), an async read request is performed on
-#      * the server. inactivityCallback is called when the client receive no
-#      * response for this read request The connection can be closed, this in an
-#      * attempt to recreate a healthy connection. */
-#     void (*inactivityCallback)(UA_Client *client);
-
-# #ifdef UA_ENABLE_SUBSCRIPTIONS
-#     /* Number of PublishResponse queued up in the server */
-#     UA_UInt16 outStandingPublishRequests;
-
-#     /* If the client does not receive a PublishResponse after the defined delay
-#      * of ``(sub->publishingInterval * sub->maxKeepAliveCount) +
-#      * client->config.timeout)``, then subscriptionInactivityCallback is called
-#      * for the subscription.. */
-#     void (*subscriptionInactivityCallback)(UA_Client *client,
-#                                            UA_UInt32 subscriptionId,
-#                                            void *subContext);
-# #endif
-
-#     UA_LocaleId *sessionLocaleIds;
-#     size_t sessionLocaleIdsSize;
-# } UA_ClientConfig;
 
 # typedef UA_Boolean
 # (*UA_HistoricalIteratorCallback)(UA_Client *client,

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -97,8 +97,8 @@ function UA_MethodCallback_generate(f::Function)
         Csize_t, Ptr{UA_Variant})
     returntype = UA_StatusCode
     ret = Base.return_types(f, argtuple)
-    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret)
-        ret[1] == returntype
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+            ret[1] == returntype
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid},
                 Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId}, Ptr{Cvoid},
@@ -195,7 +195,7 @@ function UA_ValueCallback_onRead_generate(f::Function)
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -228,7 +228,7 @@ function UA_ValueCallback_onWrite_generate(f::Function)
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -261,7 +261,7 @@ function UA_DataSourceCallback_write_generate(f::Function)
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -294,7 +294,7 @@ function UA_DataSourceCallback_read_generate(f::Function)
         callback = @cfunction($f, UA_StatusCode,
             (Ptr{UA_Server}, Ptr{UA_NodeId}, Ptr{Cvoid}, Ptr{UA_NodeId},
                 Ptr{Cvoid}, UA_Boolean, Ptr{UA_NumericRange}, Ptr{UA_DataValue}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -318,7 +318,7 @@ function UA_ServerCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Server}, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -342,7 +342,7 @@ function UA_ClientCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Client}, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -366,7 +366,7 @@ function UA_ClientAsyncServiceCallback_generate(f::Function)
     if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
        ret[1] == returntype
         callback = @cfunction($f, Nothing, (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{Cvoid}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -391,7 +391,7 @@ function UA_ClientAsyncReadCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_ReadResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -416,7 +416,7 @@ function UA_ClientAsyncWriteCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_WriteResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -441,7 +441,7 @@ function UA_ClientAsyncBrowseCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_BrowseResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -466,7 +466,7 @@ function UA_ClientAsyncAddNodesCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_AddNodesResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -491,7 +491,83 @@ function UA_ClientAsyncCallCallback_generate(f::Function)
        ret[1] == returntype
         callback = @cfunction($f, Nothing,
             (Ptr{UA_Client}, Ptr{Cvoid}, UInt32, Ptr{UA_CallResponse}))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_stateCallback_generate(f::Function)
+```
+
+creates a function pointer for the `stateCallback` field of a `UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}, channelstate::UInt32, sessionstate::UInt32, connecstatus::UInt32))::Nothing`
+"""
+function UA_ClientConfig_stateCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client}, UInt32, UInt32, UInt32)
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+            (Ptr{UA_Client}, UInt32, UInt32, UInt32))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_inactivityCallback_generate(f::Function)
+```
+
+creates a function pointer for the `inactivityCallback` field of a `UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}))::Nothing`
+"""
+function UA_ClientConfig_inactivityCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client},)
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+            (Ptr{UA_Client},))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
+    else
+        err = CallbackGeneratorArgumentError(f, argtuple, returntype)
+        throw(err)
+    end
+end
+
+"""
+```
+UA_ClientConfig_subscriptionInactivityCallback_generate(f::Function)
+```
+
+creates a function pointer for the `subscriptionInactivityCallback` field of a 
+`UA_ClientConfig` object. 
+
+`f` must be a Julia function with the following signature:
+`f(client::Ptr{UA_Client}, subscritionid::UInt32, subcontext::Ptr{CVoid}))::Nothing`
+"""
+function UA_ClientConfig_subscriptionInactivityCallback_generate(f::Function)
+    argtuple = (Ptr{UA_Client}, UInt32, Ptr{Cvoid})
+    returntype = Nothing
+    ret = Base.return_types(f, argtuple)
+    if length(methods(f)) == 1 && hasmethod(f, argtuple) && !isempty(ret) &&
+       ret[1] == returntype
+        callback = @cfunction($f, Nothing,
+           (Ptr{UA_Client}, UInt32, Ptr{Cvoid}))
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -1378,127 +1454,6 @@ end
 #      * For example for read_event, read_annotation, update_details */
 # };
 
-# typedef struct {
-#     void *clientContext; /* User-defined pointer attached to the client */
-#     UA_Logger logger;    /* Logger used by the client */
-#     UA_UInt32 timeout;   /* Response timeout in ms */
-
-#     /* The description must be internally consistent.
-#      * - The ApplicationUri set in the ApplicationDescription must match the
-#      *   URI set in the certificate */
-#     UA_ApplicationDescription clientDescription;
-
-#     /**
-#      * Connection configuration
-#      * ~~~~~~~~~~~~~~~~~~~~~~~~
-#      *
-#      * The following configuration elements reduce the "degrees of freedom" the
-#      * client has when connecting to a server. If no connection can be made
-#      * under these restrictions, then the connection will abort with an error
-#      * message. */
-#     UA_ExtensionObject userIdentityToken; /* Configured User-Identity Token */
-#     UA_MessageSecurityMode securityMode;  /* None, Sign, SignAndEncrypt. The
-#                                            * default is invalid. This indicates
-#                                            * the client to select any matching
-#                                            * endpoint. */
-#     UA_String securityPolicyUri; /* SecurityPolicy for the SecureChannel. An
-#                                   * empty string indicates the client to select
-#                                   * any matching SecurityPolicy. */
-
-#     /**
-#      * If either endpoint or userTokenPolicy has been set (at least one non-zero
-#      * byte in either structure), then the selected Endpoint and UserTokenPolicy
-#      * overwrite the settings in the basic connection configuration. The
-#      * userTokenPolicy array in the EndpointDescription is ignored. The selected
-#      * userTokenPolicy is set in the dedicated configuration field.
-#      *
-#      * If the advanced configuration is not set, the client will write to it the
-#      * selected Endpoint and UserTokenPolicy during GetEndpoints.
-#      *
-#      * The information in the advanced configuration is used during reconnect
-#      * when the SecureChannel was broken. */
-#     UA_EndpointDescription endpoint;
-#     UA_UserTokenPolicy userTokenPolicy;
-
-#     /**
-#      * If the EndpointDescription has not been defined, the ApplicationURI
-#      * constrains the servers considered in the FindServers service and the
-#      * Endpoints considered in the GetEndpoints service.
-#      *
-#      * If empty the applicationURI is not used to filter.
-#      */
-#     UA_String applicationUri;
-
-#     /**
-#      * Custom Data Types
-#      * ~~~~~~~~~~~~~~~~~
-#      * The following is a linked list of arrays with custom data types. All data
-#      * types that are accessible from here are automatically considered for the
-#      * decoding of received messages. Custom data types are not cleaned up
-#      * together with the configuration. So it is possible to allocate them on
-#      * ROM.
-#      *
-#      * See the section on :ref:`generic-types`. Examples for working with custom
-#      * data types are provided in ``/examples/custom_datatype/``. */
-#     const UA_DataTypeArray *customDataTypes;
-
-#     /**
-#      * Advanced Client Configuration
-#      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-
-#     UA_UInt32 secureChannelLifeTime; /* Lifetime in ms (then the channel needs
-#                                         to be renewed) */
-#     UA_UInt32 requestedSessionTimeout; /* Session timeout in ms */
-#     UA_ConnectionConfig localConnectionConfig;
-#     UA_UInt32 connectivityCheckInterval;     /* Connectivity check interval in ms.
-#                                               * 0 = background task disabled */
-#     /* Available SecurityPolicies */
-#     size_t securityPoliciesSize;
-#     UA_SecurityPolicy *securityPolicies;
-
-#     /* Certificate Verification Plugin */
-#     UA_CertificateVerification certificateVerification;
-
-#     /* Callbacks for async connection handshakes */
-#     UA_ConnectClientConnection initConnectionFunc;
-#     UA_StatusCode (*pollConnectionFunc)(UA_Connection *connection,
-#                                         UA_UInt32 timeout,
-#                                         const UA_Logger *logger);
-
-#     /* Callback for state changes. The client state is differentated into the
-#      * SecureChannel state and the Session state. The connectStatus is set if
-#      * the client connection (including reconnects) has failed and the client
-#      * has to "give up". If the connectStatus is not set, the client still has
-#      * hope to connect or recover. */
-#     void (*stateCallback)(UA_Client *client,
-#                           UA_SecureChannelState channelState,
-#                           UA_SessionState sessionState,
-#                           UA_StatusCode connectStatus);
-
-#     /* When connectivityCheckInterval is greater than 0, every
-#      * connectivityCheckInterval (in ms), an async read request is performed on
-#      * the server. inactivityCallback is called when the client receive no
-#      * response for this read request The connection can be closed, this in an
-#      * attempt to recreate a healthy connection. */
-#     void (*inactivityCallback)(UA_Client *client);
-
-# #ifdef UA_ENABLE_SUBSCRIPTIONS
-#     /* Number of PublishResponse queued up in the server */
-#     UA_UInt16 outStandingPublishRequests;
-
-#     /* If the client does not receive a PublishResponse after the defined delay
-#      * of ``(sub->publishingInterval * sub->maxKeepAliveCount) +
-#      * client->config.timeout)``, then subscriptionInactivityCallback is called
-#      * for the subscription.. */
-#     void (*subscriptionInactivityCallback)(UA_Client *client,
-#                                            UA_UInt32 subscriptionId,
-#                                            void *subContext);
-# #endif
-
-#     UA_LocaleId *sessionLocaleIds;
-#     size_t sessionLocaleIdsSize;
-# } UA_ClientConfig;
-
 # typedef UA_Boolean
 # (*UA_HistoricalIteratorCallback)(UA_Client *client,
 #     const UA_NodeId *nodeId,
@@ -1888,6 +1843,7 @@ end
 #                         UA_Boolean historizing,
 #                         const UA_DataValue *value);
 #         };
+
 """
 ```
 UA_ClientAsyncReadAttributeCallback_generate(f::Function)
@@ -1912,7 +1868,7 @@ function UA_ClientAsyncReadAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_DataValue))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -1943,7 +1899,7 @@ function UA_ClientAsyncReadValueAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_DataValue))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -1974,7 +1930,7 @@ function UA_ClientAsyncReadDataTypeAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_NodeId))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2005,7 +1961,7 @@ function UA_ClientReadArrayDimensionsAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Variant))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2036,7 +1992,7 @@ function UA_ClientAsyncReadNodeClassAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_NodeClass))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2067,7 +2023,7 @@ function UA_ClientAsyncReadBrowseNameAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_QualifiedName))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2098,7 +2054,7 @@ function UA_ClientAsyncReadDisplayNameAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_LocalizedText))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2129,7 +2085,7 @@ function UA_ClientAsyncReadDescriptionAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_LocalizedText))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2160,7 +2116,7 @@ function UA_ClientAsyncReadWriteMaskAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_UInt32))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2191,7 +2147,7 @@ function UA_ClientAsyncReadUserWriteMaskAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_UInt32))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2222,7 +2178,7 @@ function UA_ClientAsyncReadIsAbstractAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2253,7 +2209,7 @@ function UA_ClientAsyncReadSymmetricAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2284,7 +2240,7 @@ function UA_ClientAsyncReadInverseNameAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_LocalizedText))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2315,7 +2271,7 @@ function UA_ClientAsyncReadContainsNoLoopsAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2346,7 +2302,7 @@ function UA_ClientAsyncReadEventNotifierAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Byte))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2377,7 +2333,7 @@ function UA_ClientAsyncReadValueRankAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_UInt32))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2408,7 +2364,7 @@ function UA_ClientAsyncReadAccessLevelAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Byte))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2439,7 +2395,7 @@ function UA_ClientAsyncReadUserAccessLevelAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Byte))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2470,7 +2426,7 @@ function UA_ClientAsyncReadMinimumSamplingIntervalAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Double))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2501,7 +2457,7 @@ function UA_ClientAsyncReadHistorizingAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2532,7 +2488,7 @@ function UA_ClientAsyncReadExecutableAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)
@@ -2563,7 +2519,7 @@ function UA_ClientAsyncReadUserExecutableAttributeCallback_generate(f)
        ret[1] == returntype
         callback = @cfunction($f, Cvoid,
             (Ptr{UA_Client}, Ptr{Cvoid}, UA_UInt32, UA_StatusCode, UA_Boolean))
-        return callback
+        return Base.unsafe_convert(Ptr{Cvoid}, callback)
     else
         err = CallbackGeneratorArgumentError(f, argtuple, returntype)
         throw(err)

--- a/src/client.jl
+++ b/src/client.jl
@@ -53,15 +53,14 @@ connect the `client` to the server with `endpointurl` *asynchronously* (non-bloc
 is an anonymous connection, i.e., no username or password are used (some servers do not 
 allow this).
 
-After initiating the connection,
-call UA_Client_run_iterate repeatedly until the connection is fully established. You can set 
-a callback to client->config.stateCallback to be notified when the connection status 
-changes. Or use UA_Client_getState to get the state manually.
+After initiating the connection, call `UA_Client_run_iterate` repeatedly until the connection 
+is fully established. You can set a callback to client->config.stateCallback to be notified 
+when the connection status changes. Or use `UA_Client_getState` to get the state manually.
 
 Note that `endpointurl` is copied; pointer must be cleared up separately.
 
 """
-function UA_Client_connectAsync(client, endpointUrl)
+function UA_Client_connectAsync(client, endpointurl)
     cc = UA_Client_getConfig(client)
     cc.noSession = false
     UA_String_clear(cc.endpointUrl)

--- a/src/client.jl
+++ b/src/client.jl
@@ -45,26 +45,43 @@ function UA_Client_connect(client, endpointurl)
     return __UA_Client_connect(client, false)
 end
 
-# /* Connect async (non-blocking) to the server. After initiating the connection,
-#  * call UA_Client_run_iterate repeatedly until the connection is fully
-#  * established. You can set a callback to client->config.stateCallback to be
-#  * notified when the connection status changes. Or use UA_Client_getState to get
-#  * the state manually. */
-##TODO: ADD DOCSTRING
-function UA_Client_connectAsync(client::Ptr{UA_Client}, endpointUrl::AbstractString)
+"""
+```
+UA_Client_connectAsync(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String})::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking). This 
+is an anonymous connection, i.e., no username or password are used (some servers do not 
+allow this).
+
+After initiating the connection,
+call UA_Client_run_iterate repeatedly until the connection is fully established. You can set 
+a callback to client->config.stateCallback to be notified when the connection status 
+changes. Or use UA_Client_getState to get the state manually.
+
+Note that `endpointurl` is copied; pointer must be cleared up separately.
+
+"""
+function UA_Client_connectAsync(client, endpointUrl)
     cc = UA_Client_getConfig(client)
     cc.noSession = false
     UA_String_clear(cc.endpointUrl)
-    cc.endpointUrl = UA_STRING_ALLOC(endpointUrl)
+    UA_String_copy(endpointurl, cc.endpointUrl) 
     return __UA_Client_connect(client, true)
 end
 
-# /* Connect to the server without creating a session
-#  *
-#  * @param client to use
-#  * @param endpointURL to connect (for example "opc.tcp://localhost:4840")
-#  * @return Indicates whether the operation succeeded or returns an error code */
-##TODO: ADD DOCSTRING
+"""
+```
+UA_Client_connectSecureChannel(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String})::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` without creating a session. This is an 
+anonymous connection, i.e., no username or password are used (some servers do not allow 
+this).
+
+Note that `endpointurl` is copied; pointer must be cleared up separately.
+
+"""
 function UA_Client_connectSecureChannel(client::Ptr{UA_Client}, endpointUrl::AbstractString)
     cc = UA_Client_getConfig(client)
     cc.noSession = true
@@ -73,13 +90,28 @@ function UA_Client_connectSecureChannel(client::Ptr{UA_Client}, endpointUrl::Abs
     return __UA_Client_connect(client, false)
 end
 
-# /* Connect async (non-blocking) only the SecureChannel */
+"""
+```
+UA_Client_connectSecureChannelAsync(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String})::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking) 
+without creating a session. This is an anonymous connection, i.e., no username or password 
+are used (some servers do not allow this).
+
+After initiating the connection, call UA_Client_run_iterate repeatedly until the connection 
+is fully established. You can set a callback to client->config.stateCallback to be notified 
+when the connection status changes. Or use UA_Client_getState to get the state manually.
+
+Note that `endpointurl` is copied; pointer must be cleared up separately.
+
+"""
 function UA_Client_connectSecureChannelAsync(
-        client::Ptr{UA_Client}, endpointUrl::AbstractString)
+        client, endpointUrl)
     cc = UA_Client_getConfig(client)
     cc.noSession = true
     UA_String_clear(cc.endpointUrl)
-    cc.endpointUrl = UA_STRING_ALLOC(endpointUrl)
+    UA_String_copy(endpointurl, cc.endpointUrl) 
     return __UA_Client_connect(client, true)
 end
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -101,8 +101,7 @@ when the connection status changes. Or use `UA_Client_getState` to get the state
 Note that `endpointurl` is copied; pointer must be cleared up separately.
 
 """
-function UA_Client_connectSecureChannelAsync(
-        client, endpointUrl)
+function UA_Client_connectSecureChannelAsync(client, endpointurl)
     cc = UA_Client_getConfig(client)
     cc.noSession = true
     UA_String_clear(cc.endpointUrl)

--- a/src/client.jl
+++ b/src/client.jl
@@ -10,8 +10,7 @@ Configure Username/Password for the Session authentication. Also see
 Note that `username` and `password` are copied; pointers must be cleared up separately.
 
 """
-function UA_ClientConfig_setAuthenticationUsername(config::Ptr{UA_ClientConfig}, username::Ptr{UA_String}, 
-        password::Ptr{UA_String})
+function UA_ClientConfig_setAuthenticationUsername(config, username, password)
     identityToken = UA_UserNameIdentityToken_new()
     if identityToken == C_NULL
         return UA_STATUSCODE_BADOUTOFMEMORY
@@ -126,8 +125,8 @@ UA_Client_getContext(client::Ptr{UA_Client}) = UA_Client_getConfig(client).clien
 
 """
 ```
-UA_Client_connectUsername(client::Ptr{UA_Client}, endpointurl::Ptr[UA_String}, 
-    username::Ptr[UA_String}, password::Ptr[UA_String})::UA_StatusCode
+UA_Client_connectUsername(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String}, 
+    username::Ptr[UA_String}, password::Ptr{UA_String})::UA_StatusCode
 ```
 
 connects the `client` to the server with endpoint URL `endpointurl` and supplies

--- a/src/client.jl
+++ b/src/client.jl
@@ -73,9 +73,7 @@ end
 UA_Client_connectSecureChannel(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String})::UA_StatusCode
 ```
 
-connect the `client` to the server with `endpointurl` without creating a session. This is an 
-anonymous connection, i.e., no username or password are used (some servers do not allow 
-this).
+connect the `client` to the server with `endpointurl` without creating a session. 
 
 Note that `endpointurl` is copied; pointer must be cleared up separately.
 
@@ -94,12 +92,11 @@ UA_Client_connectSecureChannelAsync(client::Ptr{UA_Client}, endpointurl::Ptr{UA_
 ```
 
 connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking) 
-without creating a session. This is an anonymous connection, i.e., no username or password 
-are used (some servers do not allow this).
+without creating a session.
 
-After initiating the connection, call UA_Client_run_iterate repeatedly until the connection 
+After initiating the connection, call `UA_Client_run_iterate` repeatedly until the connection 
 is fully established. You can set a callback to client->config.stateCallback to be notified 
-when the connection status changes. Or use UA_Client_getState to get the state manually.
+when the connection status changes. Or use `UA_Client_getState` to get the state manually.
 
 Note that `endpointurl` is copied; pointer must be cleared up separately.
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -112,17 +112,8 @@ end
 
 """
 ```
-UA_Client_getContext(client::Ptr{UA_Client})::Ptr{Ptr{Cvoid}}
-```
-
-Get the client context.
-"""
-UA_Client_getContext(client::Ptr{UA_Client}) = UA_Client_getConfig(client).clientContext
-
-"""
-```
 UA_Client_connectUsername(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String}, 
-    username::Ptr[UA_String}, password::Ptr{UA_String})::UA_StatusCode
+    username::Ptr{UA_String}, password::Ptr{UA_String})::UA_StatusCode
 ```
 
 connects the `client` to the server with endpoint URL `endpointurl` and supplies
@@ -140,6 +131,37 @@ function UA_Client_connectUsername(client, endpointurl, username, password)
         return UA_Client_connect(client, endpointurl)
     end
 end
+
+"""
+```
+UA_Client_connectUsernameAsync(client::Ptr{UA_Client}, endpointurl::Ptr{UA_String}, 
+    username::Ptr{UA_String}, password::Ptr{UA_String})::UA_StatusCode
+```
+
+connects the `client` to the server with endpoint URL `endpointurl` and supplies
+`username` and `password` as login credentials.
+
+Note that `endpointurl`, `username`, and `password` are copied, pointers must be freed up 
+seperately.
+"""
+function UA_Client_connectUsernameAsync(client, endpointurl, username, password)
+    cc = UA_Client_getConfig(client)
+    res = UA_ClientConfig_setAuthenticationUsername(cc, username, password)
+    if res != UA_STATUSCODE_GOOD
+        return res
+    else
+        return UA_Client_connectAsync(client, endpointurl)
+    end
+end
+
+"""
+```
+UA_Client_getContext(client::Ptr{UA_Client})::Ptr{Ptr{Cvoid}}
+```
+
+Get the client context.
+"""
+UA_Client_getContext(client) = UA_Client_getConfig(client).clientContext
 
 ## UA_Client_Service functions
 for att in attributes_UA_Client_Service

--- a/src/highlevel_client.jl
+++ b/src/highlevel_client.jl
@@ -104,6 +104,21 @@ function JUA_Client_connectAsync(client, endpointurl)
     return sc
 end
 
+"""
+```
+JUA_Client_connectSecureChannel(client::JUA_Client, endpointurl::AbstractString)::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` without creating a session.
+
+"""
+function JUA_Client_connectSecureChannel(client::JUA_Client, endpointurl::AbstractString)
+    endpointurl_ptr = UA_STRING_ALLOC(endpointurl)
+    sc = UA_Client_connect(client, endpointurl_ptr)
+    UA_String_delete(endpointurl_ptr)
+    return sc
+end
+
 const JUA_Client_disconnect = UA_Client_disconnect
 
 """

--- a/src/highlevel_client.jl
+++ b/src/highlevel_client.jl
@@ -83,6 +83,27 @@ function JUA_Client_connectUsername(client::JUA_Client, endpointurl::AbstractStr
     return sc
 end
 
+"""
+```
+JUA_Client_connectAsync(client::JUA_Client, endpointurl::AbstractString)::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking). This 
+is an anonymous connection, i.e., no username or password are used (some servers do not 
+allow this).
+
+After initiating the connection, call `UA_Client_run_iterate` repeatedly until the connection 
+is fully established. You can set a callback to client->config.stateCallback to be notified 
+when the connection status changes. Or use `JUA_Client_getState` to get the state manually.
+
+"""
+function JUA_Client_connectAsync(client, endpointurl)
+    endpointurl_ptr = UA_STRING_ALLOC(endpointurl) 
+    sc = UA_Client_connectAsync(client, endpointurl_ptr)
+    UA_String_delete(endpointurl_ptr)
+    return sc
+end
+
 const JUA_Client_disconnect = UA_Client_disconnect
 
 """
@@ -245,7 +266,8 @@ value = JUA_Client_readValueAttribute(client::JUA_Client, nodeId::JUA_NodeId, ty
 ```
 
 uses the client API to read the value of `nodeId` from the server that the `client`
-is connected to.
+is connected to. In case the client has no live connection to a server, automatic 
+reconnection is attempted.
 
 The output `value` is automatically converted to a Julia type (such as Float64, String, Vector{String},
 etc.) if possible. Otherwise, open62541 composite types are returned.
@@ -273,11 +295,12 @@ end
 
 """
 ```
-JUA_Client_writeValueAttribute(server::JUA_Client, nodeId::JUA_NodeId, newvalue)::UA_StatusCode
+JUA_Client_writeValueAttribute(client::JUA_Client, nodeId::JUA_NodeId, newvalue)::UA_StatusCode
 ```
 
 uses the client API to write the value `newvalue` to `nodeId` to the server that
-the `client` is connected to.
+the `client` is connected to. In case the client has no live connection to a server, 
+automatic reconnection is attempted.
 
 `new_value` must either be a `JUA_Variant` or a Julia value/array compatible with
 any of its constructors.

--- a/src/highlevel_client.jl
+++ b/src/highlevel_client.jl
@@ -96,6 +96,14 @@ After initiating the connection, call `UA_Client_run_iterate` repeatedly until t
 is fully established. You can set a callback to client->config.stateCallback to be notified 
 when the connection status changes. Or use `JUA_Client_getState` to get the state manually.
 
+See also:
+
+[`JUA_Client_getState`](@ref)
+
+[`UA_ClientConfig_stateCallback_generate`](@ref)
+
+[`UA_Client_run_iterate`](@ref)
+
 """
 function JUA_Client_connectAsync(client, endpointurl)
     endpointurl_ptr = UA_STRING_ALLOC(endpointurl) 
@@ -115,6 +123,56 @@ connect the `client` to the server with `endpointurl` without creating a session
 function JUA_Client_connectSecureChannel(client::JUA_Client, endpointurl::AbstractString)
     endpointurl_ptr = UA_STRING_ALLOC(endpointurl)
     sc = UA_Client_connect(client, endpointurl_ptr)
+    UA_String_delete(endpointurl_ptr)
+    return sc
+end
+
+"""
+```
+JUA_Client_connectSecureChannelAsync(client::JUA_Client, endpointurl::AbstractString)::UA_StatusCode
+```
+
+connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking) 
+without creating a session.
+
+After initiating the connection, call `UA_Client_run_iterate` repeatedly until the connection 
+is fully established. You can set a callback to client->config.stateCallback to be notified 
+when the connection status changes. Or use `JUA_Client_getState` to get the state manually.
+
+See also:
+
+[`JUA_Client_getState`](@ref)
+
+[`UA_ClientConfig_stateCallback_generate`](@ref)
+
+[`UA_Client_run_iterate`](@ref)
+
+"""
+function JUA_Client_connectSecureChannelAsync(client, endpointurl)
+    endpointurl_ptr = UA_STRING_ALLOC(endpointurl)
+    sc = UA_Client_secureChannelAsync(client, endpointurl)
+    UA_String_delete(endpointurl_ptr)
+    return sc
+end
+
+"""
+```
+JUA_Client_connectUsername(client::JUA_Client, endpointurl::AbstractString, 
+    username::AbstractString, password::AbstractString)::UA_StatusCode
+```
+
+connects the `client` to the server with endpoint URL `endpointurl` and supplies
+`username` and `password` as login credentials.
+
+"""
+function JUA_Client_connectUsernameAsync(client::JUA_Client, endpointurl::AbstractString, 
+        username::AbstractString, password::AbstractString)
+    username_ptr = UA_STRING_ALLOC(username)
+    password_ptr = UA_STRING_ALLOC(password)
+    endpointurl_ptr = UA_STRING_ALLOC(endpointurl)
+    sc = UA_Client_connectUsernameAsync(client, endpointurl_ptr, username_ptr, password_ptr)
+    UA_String_delete(username_ptr)
+    UA_String_delete(password_ptr)
     UA_String_delete(endpointurl_ptr)
     return sc
 end

--- a/src/highlevel_client.jl
+++ b/src/highlevel_client.jl
@@ -27,6 +27,25 @@ const JUA_ClientConfig_setDefault = UA_ClientConfig_setDefault
 
 """
 ```
+JUA_ClientConfig_setAuthenticationUsername(config::JUA_ClientConfig, username::AbstractString, 
+    password::AbstractString)::UA_StatusCode
+```
+
+Configure Username/Password for the Session authentication. Also see 
+`JUA_ClientConfig_setAuthenticationCert` for x509-based authentication.
+
+
+"""
+function JUA_ClientConfig_setAuthenticationUsername(config::JUA_ClientConfig, username::AbstractString, 
+        password::AbstractString)
+    username_ptr = UA_STRING_ALLOC(username)
+    password_ptr = UA_STRING_ALLOC(password) 
+    sc = UA_ClientConfig_setAuthenticationUsername(config, username_ptr, password_ptr)
+    return sc
+end
+
+"""
+```
 JUA_Client_connect(client::JUA_Client, endpointurl::AbstractString)::UA_StatusCode
 ```
 
@@ -76,7 +95,8 @@ returns the state of the `client`, particularly:
 - `sessionState`: the status of the session between client and server.
 - `connectStatus`: the status of the connection between client and server. 
 
-The returned values are `UInt32`, whose meaning is documented in 
+The returned values are `UInt32`, whose meaning is documented in `UA_SecureChannelState`, 
+`UA_SessionState` and `UA_ConnectionState`.
 
 """
 function JUA_Client_getState(client::JUA_Client)

--- a/src/highlevel_client.jl
+++ b/src/highlevel_client.jl
@@ -150,19 +150,31 @@ See also:
 """
 function JUA_Client_connectSecureChannelAsync(client, endpointurl)
     endpointurl_ptr = UA_STRING_ALLOC(endpointurl)
-    sc = UA_Client_secureChannelAsync(client, endpointurl)
+    sc = UA_Client_connectSecureChannelAsync(client, endpointurl_ptr)
     UA_String_delete(endpointurl_ptr)
     return sc
 end
 
 """
 ```
-JUA_Client_connectUsername(client::JUA_Client, endpointurl::AbstractString, 
+JUA_Client_connectUsernameAsync(client::JUA_Client, endpointurl::AbstractString, 
     username::AbstractString, password::AbstractString)::UA_StatusCode
 ```
 
-connects the `client` to the server with endpoint URL `endpointurl` and supplies
-`username` and `password` as login credentials.
+connect the `client` to the server with `endpointurl` *asynchronously* (non-blocking) 
+and supplies `username` and `password` as login credentials.
+
+After initiating the connection, call `UA_Client_run_iterate` repeatedly until the connection 
+is fully established. You can set a callback to client->config.stateCallback to be notified 
+when the connection status changes. Or use `JUA_Client_getState` to get the state manually.
+
+See also:
+
+[`JUA_Client_getState`](@ref)
+
+[`UA_ClientConfig_stateCallback_generate`](@ref)
+
+[`UA_Client_run_iterate`](@ref)
 
 """
 function JUA_Client_connectUsernameAsync(client::JUA_Client, endpointurl::AbstractString, 

--- a/src/highlevel_server.jl
+++ b/src/highlevel_server.jl
@@ -156,8 +156,8 @@ The `method` supplied can either be a Julia function that fulfills the requireme
 
 See also:
 - [`JUA_MethodAttributes`](@ref) for how to define valid attributes.
-- [`JUA_MethodCallback_generate`](@ref) for requirements on `method`.
-- [`JUA_MethodCallback_wrap`](@ref) for requirements on `method`.
+- [`UA_MethodCallback_generate`](@ref) for requirements on `method`.
+- [`UA_MethodCallback_wrap`](@ref) for requirements on `method`.
 """
 function JUA_Server_addNode(server, requestedNewNodeId,
         parentNodeId, referenceTypeId, browseName,

--- a/test/client_connections.jl
+++ b/test/client_connections.jl
@@ -64,8 +64,30 @@ sleep_time = 2.0 # Sleep time in seconds between each connection trial
 let trial
     trial = 0
     while trial < max_duration / sleep_time
-        retval1 = JUA_Client_connectUsername(client, "opc.tcp://localhost:4840", "user",
-                "password")        
+        retval1 = JUA_Client_connectUsername(client, "opc.tcp://localhost:4840", 
+            "PeterParker", "IamSpiderman")        
+        if retval == UA_STATUSCODE_GOOD
+            println("Connection established.")
+            break
+        end
+        sleep(sleep_time)
+        trial = trial + 1
+    end
+    @test trial < max_duration / sleep_time # Check if maximum number of trials has been exceeded
+end
+retval = JUA_Client_disconnect(client)
+@test retval == UA_STATUSCODE_GOOD
+
+# Set password and username with connect command
+client = JUA_Client()
+config = JUA_ClientConfig(client)
+JUA_ClientConfig_setDefault(config)
+max_duration = 90.0 # Maximum waiting time for server startup 
+sleep_time = 2.0 # Sleep time in seconds between each connection trial
+let trial
+    trial = 0
+    while trial < max_duration / sleep_time
+        retval1 = JUA_Client_connectSecureChannel(client, "opc.tcp://localhost:4840")        
         if retval == UA_STATUSCODE_GOOD
             println("Connection established.")
             break

--- a/test/client_connections.jl
+++ b/test/client_connections.jl
@@ -113,7 +113,7 @@ end
 @static if !Sys.isapple() || platform_key_abi().tags["arch"] != "aarch64"
     cb = UA_ClientConfig_stateCallback_generate(stateCallback)
 else #we are on Apple Silicon and can't use a closure in @cfunction, so do it manually
-    cb = @cfunction(stateCallback, nothing,
+    cb = @cfunction(stateCallback, Nothing,
         (Ptr{UA_Client}, UInt32, UInt32, UInt32))
 end
 config.stateCallback = cb

--- a/test/client_connections.jl
+++ b/test/client_connections.jl
@@ -125,11 +125,11 @@ let trial
     while trial < max_duration / sleep_time
         retval1 = JUA_Client_connectAsync(client, "opc.tcp://localhost:4840")   
         i = 0
-        while i < 100 && !all(status .== (UInt32(UA_SECURECHANNELSTATE_OPEN), 
-                UInt32(UA_SESSIONSTATE_ACTIVATED), UInt32(UA_CONNECTIONSTATE_CLOSED)))
+        while i < 10 && !all(status .== (UA_SECURECHANNELSTATE_OPEN, 
+                UA_SESSIONSTATE_ACTIVATED, UA_CONNECTIONSTATE_CLOSED))
             UA_Client_run_iterate(client, 10)
         end     
-        if retval == UA_STATUSCODE_GOOD
+        if retval1 == UA_STATUSCODE_GOOD
             println("Connection established.")
             break
         end
@@ -141,7 +141,57 @@ end
 retval = JUA_Client_disconnect(client)
 @test retval == UA_STATUSCODE_GOOD
 
-#TODO: introduce tests for connectusernameasync, connectsecurechannelasync
+#connectusernameasync
+status = (m, m, m)
+max_duration = 90.0 # Maximum waiting time for server startup 
+sleep_time = 2.0 # Sleep time in seconds between each connection trial
+let trial
+    trial = 0
+    while trial < max_duration / sleep_time
+        retval1 = JUA_Client_connectUsernameAsync(client, "opc.tcp://localhost:4840", "PeterParker", "IamSpiderman")   
+        i = 0
+        while i < 10 && !all(status .== (UA_SECURECHANNELSTATE_OPEN, 
+                UA_SESSIONSTATE_ACTIVATED, UA_CONNECTIONSTATE_CLOSED))
+            UA_Client_run_iterate(client, 10)
+            @show status
+        end     
+        if retval1 == UA_STATUSCODE_GOOD
+            println("Connection established.")
+            break
+        end
+        sleep(sleep_time)
+        trial = trial + 1
+    end
+    @test trial < max_duration / sleep_time # Check if maximum number of trials has been exceeded
+end
+retval = JUA_Client_disconnect(client)
+@test retval == UA_STATUSCODE_GOOD
+
+#connectsecurechannelasync
+status = (m, m, m)
+max_duration = 90.0 # Maximum waiting time for server startup 
+sleep_time = 2.0 # Sleep time in seconds between each connection trial
+let trial
+    trial = 0
+    while trial < max_duration / sleep_time
+        retval1 = JUA_Client_connectSecureChannelAsync(client, "opc.tcp://localhost:4840")   
+        i = 0
+        while i < 10 && !all(status .== (UA_SECURECHANNELSTATE_OPEN, 
+                UA_SESSIONSTATE_CLOSED, UA_CONNECTIONSTATE_CLOSED))
+            UA_Client_run_iterate(client, 10)
+            @show status
+        end     
+        if retval1 == UA_STATUSCODE_GOOD
+            println("Connection established.")
+            break
+        end
+        sleep(sleep_time)
+        trial = trial + 1
+    end
+    @test trial < max_duration / sleep_time # Check if maximum number of trials has been exceeded
+end
+retval = JUA_Client_disconnect(client)
+@test retval == UA_STATUSCODE_GOOD
 
 println("Ungracefully kill server process...")
 Distributed.interrupt(Distributed.workers()[end])

--- a/test/client_connectiontests.jl
+++ b/test/client_connectiontests.jl
@@ -1,0 +1,83 @@
+# Purpose: This testset checks whether connection functions used to connect a client in 
+# various ways to a server are functioning. Focus is on the high level interface.
+
+using Distributed
+Distributed.addprocs(1) # Add a single worker process to run the server
+
+Distributed.@everywhere begin
+    using Open62541
+    using Test
+end
+
+# Create nodes with random default values on new server running at a worker process
+Distributed.@spawnat Distributed.workers()[end] begin
+    server = JUA_Server()
+    config = JUA_ServerConfig(server)
+    retval0 = JUA_ServerConfig_setDefault(config)
+    @test retval0 == UA_STATUSCODE_GOOD
+    @test isa(server, JUA_Server)
+
+    server = JUA_Server()
+    config = JUA_ServerConfig(server)
+    JUA_ServerConfig_setDefault(config)
+    login = JUA_UsernamePasswordLogin("PeterParker", "IamSpiderman")
+    retval1 = UA_AccessControl_default(config, false,
+        Ref(unsafe_load(unsafe_load(config.securityPolicies)).policyUri), 1, Ref(login.login))
+    config.allowNonePolicyPassword = true #allow logging in with username/password on un-encrypted connections.
+    @test retval1 == UA_STATUSCODE_GOOD
+
+    # Start up the server
+    Distributed.@spawnat Distributed.workers()[end] redirect_stderr() # Turn off all error messages
+    println("Starting up the server...")
+    JUA_Server_runUntilInterrupt(server)
+end
+
+# Set password and username outside of connect command
+client = JUA_Client()
+config = JUA_ClientConfig(client)
+JUA_ClientConfig_setDefault(config)
+JUA_ClientConfig_setAuthenticationUsername(config, "PeterParker", "IamSpiderman")
+max_duration = 90.0 # Maximum waiting time for server startup 
+sleep_time = 2.0 # Sleep time in seconds between each connection trial
+let trial
+    trial = 0
+    while trial < max_duration / sleep_time
+        retval = JUA_Client_connect(client, "opc.tcp://localhost:4840")
+        if retval == UA_STATUSCODE_GOOD
+            println("Connection established.")
+            break
+        end
+        sleep(sleep_time)
+        trial = trial + 1
+    end
+    @test trial < max_duration / sleep_time # Check if maximum number of trials has been exceeded
+end
+retval = JUA_Client_disconnect(client)
+@test retval == UA_STATUSCODE_GOOD
+
+# Set password and username with connect command
+client = JUA_Client()
+config = JUA_ClientConfig(client)
+JUA_ClientConfig_setDefault(config)
+max_duration = 90.0 # Maximum waiting time for server startup 
+sleep_time = 2.0 # Sleep time in seconds between each connection trial
+let trial
+    trial = 0
+    while trial < max_duration / sleep_time
+        retval1 = JUA_Client_connectUsername(client, "opc.tcp://localhost:4840", "user",
+                "password")        
+        if retval == UA_STATUSCODE_GOOD
+            println("Connection established.")
+            break
+        end
+        sleep(sleep_time)
+        trial = trial + 1
+    end
+    @test trial < max_duration / sleep_time # Check if maximum number of trials has been exceeded
+end
+retval = JUA_Client_disconnect(client)
+@test retval == UA_STATUSCODE_GOOD
+
+println("Ungracefully kill server process...")
+Distributed.interrupt(Distributed.workers()[end])
+Distributed.rmprocs(Distributed.workers()[end]; waitfor = 0)

--- a/test/client_read.jl
+++ b/test/client_read.jl
@@ -92,7 +92,9 @@ sleep_time = 2.0 # Sleep time in seconds between each connection trial
 let trial
     trial = 0
     while trial < max_duration / sleep_time
-        retval = UA_Client_connect(client, "opc.tcp://localhost:4842")
+        url_ptr = UA_STRING_ALLOC("opc.tcp://localhost:4842")
+        retval = UA_Client_connect(client, url_ptr)
+        UA_String_delete(url_ptr)
         if retval == UA_STATUSCODE_GOOD
             println("Connection established.")
             break

--- a/test/client_service.jl
+++ b/test/client_service.jl
@@ -30,7 +30,9 @@ sleep_time = 3.0 # Sleep time in seconds between each connection trial
 let trial
     trial = 0
     while trial < max_duration / sleep_time
-        retval = UA_Client_connect(client, "opc.tcp://localhost:4842")
+        url_ptr = UA_STRING_ALLOC("opc.tcp://localhost:4842")
+        retval = UA_Client_connect(client, url_ptr)
+        UA_String_delete(url_ptr)
         if retval == UA_STATUSCODE_GOOD
             println("Connection established.")
             break

--- a/test/client_subscriptions.jl
+++ b/test/client_subscriptions.jl
@@ -44,7 +44,9 @@ sleep_time = 3.0 # Sleep time in seconds between each connection trial
 let trial
     trial = 0
     while trial < max_duration / sleep_time
-        retval = UA_Client_connect(client, "opc.tcp://localhost:4843")
+        url_ptr = UA_STRING_ALLOC("opc.tcp://localhost:4843")
+        retval = UA_Client_connect(client, url_ptr)
+        UA_String_delete(url_ptr)
         if retval == UA_STATUSCODE_GOOD
             println("Connection established.")
             break

--- a/test/client_write.jl
+++ b/test/client_write.jl
@@ -110,7 +110,9 @@ sleep_time = 2.0 # Sleep time in seconds between each connection trial
 let trial
     trial = 0
     while trial < max_duration / sleep_time
-        retval = UA_Client_connect(client, "opc.tcp://localhost:4842")
+        url_ptr = UA_STRING_ALLOC("opc.tcp://localhost:4842")
+        retval = UA_Client_connect(client, url_ptr)
+        UA_String_delete(url_ptr)
         if retval == UA_STATUSCODE_GOOD
             println("Connection established.")
             break

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,7 @@ end
 end
 
 @testset "Client connections" begin
-    include("client_connectiontests.jl")
+    include("client_connections.jl")
 end
 
 @testset "Client subscriptions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,10 @@ end
     include("client_simple.jl")
 end
 
+@testset "Client connections" begin
+    include("client_connectiontests.jl")
+end
+
 @testset "Client subscriptions" begin
     include("client_subscriptions.jl")
 end


### PR DESCRIPTION
This PR introduces functionality that automatically reconnects a client to a server when trying to read value attributes from nodes (this is useful for example when a session timeout has occurred due to inactivity). Addresses: https://github.com/martinkosch/Open62541.jl/issues/44

To clean up the interface, higher level connect functions have been introduced that accept ´AbstractString´ endpointUrls, whereas the low level interface versions are now consistent with the open62541 implementation in so far as they require endpointurls to be supplied as `Ptr{UA_String}`s.

**Still left to do:**

- [x] Complete docstrings for client connect functions.
- [x] Reformulate docstring for `JUA_Client_writeValueAttribute` and `JUA_Client_writeValueAttribute` highlighting reconnect functionality.
- [x] Introduce tests for all client connect functions in a dedicated file.
- [x] Update documentation
- [x] Bump version number (breaking change, due to interface changes)